### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 tensorflow==2.13.1
+setuptools


### PR DESCRIPTION
To see if this fixes the build error for python 3.12 where they removed `setuptools`